### PR TITLE
Add disabled config to triage

### DIFF
--- a/functions/src/default.ts
+++ b/functions/src/default.ts
@@ -69,7 +69,9 @@ Please help to unblock it by resolving these conflicts. Thanks!`,
 If you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help.`
   },
 
-  triage: {
+  triage: {    
+    // set to true to disable
+    disabled: false,
     // number of the milestone to apply when the issue has not been triaged yet
     needsTriageMilestone: 83,
     // number of the milestone to apply when the issue is triaged
@@ -114,6 +116,7 @@ export interface MergeConfig {
 }
 
 export interface TriageConfig {
+  disabled: boolean;
   needsTriageMilestone: number;
   defaultMilestone: number;
   l1TriageLabels: string[][];

--- a/functions/src/plugins/triage.ts
+++ b/functions/src/plugins/triage.ts
@@ -71,6 +71,9 @@ export class TriageTask extends Task {
   async checkTriage(context: Context): Promise<any> {
     const issue: any = context.payload.issue;
     const config = await this.getConfig(context);
+    if (config.disabled) {
+      return;
+    }
     const {owner, repo} = context.repo();
     // getting labels from Github because we might be adding multiple labels at once
     const labels = await getGhLabels(context.github, owner, repo, issue.number);

--- a/test/fixtures/angular-robot.yml
+++ b/test/fixtures/angular-robot.yml
@@ -85,6 +85,8 @@ merge:
 
 # options for the triage plugin
 triage:
+  # set to true to disable
+  disabled: false
   # number of the milestone to apply when the issue has not been triaged yet
   needsTriageMilestone: 83,
   # number of the milestone to apply when the issue is triaged


### PR DESCRIPTION
Add ability to disable the triage actions of the bot, still defaulting to the triage actions being active.