### PR TITLE
fix(size): set status to success when there is no baseline

### DIFF
--- a/functions/src/plugins/size.ts
+++ b/functions/src/plugins/size.ts
@@ -124,7 +124,7 @@ export class SizeTask extends Task {
 
     if (targetBranchArtifacts.length === 0) {
       await this.setStatus(
-        STATUS_STATE.Error,
+        STATUS_STATE.Success,
         `No baseline available for ${pr.base.ref} / ${pr.base.sha}`,
         config.status.context,
         context,


### PR DESCRIPTION
so that we don't block PRs just because we don't have a baseline