### PR TITLE
Cache more

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -131,3 +131,24 @@ exports.initRepoPRs = firestore.document('repositories/{id}').onCreate((snapshot
     console.error(err);
   });
 });
+
+/**
+ * Delete the cache for config files.
+ * This can be used to force a refresh if the cached config is wrong (if we missed the push event for example).
+ */
+exports.deleteCachedConfigs = https.onRequest(async (request: Request, response: Response) => {
+  try {
+    await tasks.commonTask.deleteCachedConfigs().catch(err => {
+      console.error(err);
+    });
+    response.send({
+      statusCode: 200,
+      body: JSON.stringify({
+        message: 'All cached configurations have been deleted'
+      })
+    });
+  } catch(err) {
+    console.error(err);
+    response.sendStatus(500);
+  }
+});

--- a/functions/src/plugins/merge.ts
+++ b/functions/src/plugins/merge.ts
@@ -1,11 +1,9 @@
 import Github from '@octokit/rest';
 import {Application, Context} from "probot";
-import {AppConfig, appConfig, MergeConfig} from "../default";
+import {MergeConfig} from "../default";
 import {addComment, addLabels, getGhPRLabels, getLabelsNames, matchAny, matchAnyFile, queryPR} from "./common";
 import {Task} from "./task";
 import {default as GithubGQL, AUTHOR_ASSOCIATION, REVIEW_STATE, STATUS_STATE, CachedPullRequest} from "../typings";
-
-export const CONFIG_FILE = "angular-robot.yml";
 
 // TODO(ocombe): create Typescript interfaces for each payload & DB data
 export class MergeTask extends Task {
@@ -574,7 +572,7 @@ export class MergeTask extends Task {
    * Gets the config for the merge plugin from Github or uses default if necessary
    */
   async getConfig(context: Context): Promise<MergeConfig> {
-    const repositoryConfig = await context.config<AppConfig>(CONFIG_FILE, appConfig);
+    const repositoryConfig = await this.getAppConfig(context);
     return repositoryConfig.merge;
   }
 }

--- a/functions/src/plugins/merge.ts
+++ b/functions/src/plugins/merge.ts
@@ -13,7 +13,8 @@ export class MergeTask extends Task {
     super(robot, db);
 
     // Pushes to the repository to check for merge conflicts
-    this.dispatch('push', this.onPush.bind(this));
+    // TODO(ocombe): disabled for now because of API rate errors
+    // this.dispatch('push', this.onPush.bind(this));
     // PR receives a new label
     this.dispatch('pull_request.labeled', this.onPRLabeled.bind(this));
     // PR looses a label

--- a/functions/src/plugins/size.ts
+++ b/functions/src/plugins/size.ts
@@ -1,11 +1,9 @@
 import fetch from 'node-fetch';
 import {Application, Context} from "probot";
 import {Task} from "./task";
-import {SizeConfig, appConfig as defaultAppConfig, AppConfig} from "../default";
+import {SizeConfig, appConfig as defaultAppConfig} from "../default";
 import {STATUS_STATE} from "../typings";
 import Github from '@octokit/rest';
-
-export const CONFIG_FILE = "angular-robot.yml";
 
 export interface CircleCiArtifact {
   path: string;
@@ -50,7 +48,7 @@ export class SizeTask extends Task {
   }
 
   async checkSize(context: Context): Promise<void> {
-    const appConfig = await context.config<AppConfig>(CONFIG_FILE);
+    const appConfig = await this.getAppConfig(context);
 
     if(!appConfig.size || appConfig.size.disabled) {
       return;

--- a/functions/src/plugins/triage.ts
+++ b/functions/src/plugins/triage.ts
@@ -1,7 +1,6 @@
 import {Application, Context} from "probot";
 import {Task} from "./task";
-import {CONFIG_FILE} from "./merge";
-import {AdminConfig, AppConfig, appConfig, TriageConfig} from "../default";
+import {AdminConfig, TriageConfig} from "../default";
 import {getLabelsNames, matchAllOfAny} from "./common";
 import Github from '@octokit/rest';
 
@@ -120,7 +119,7 @@ export class TriageTask extends Task {
    * Gets the config for the merge plugin from Github or uses default if necessary
    */
   async getConfig(context: Context): Promise<TriageConfig> {
-    const repositoryConfig = await context.config<AppConfig>(CONFIG_FILE, appConfig);
+    const repositoryConfig = await this.getAppConfig(context);
     const config = repositoryConfig.triage;
     config.defaultMilestone = parseInt(<unknown>config.defaultMilestone as string, 10);
     config.needsTriageMilestone = parseInt(<unknown>config.needsTriageMilestone as string, 10);

--- a/functions/src/plugins/triagePR.ts
+++ b/functions/src/plugins/triagePR.ts
@@ -1,7 +1,6 @@
 import {Application, Context} from "probot";
 import {Task} from "./task";
-import {CONFIG_FILE} from "./merge";
-import {AdminConfig, AppConfig, appConfig, TriageConfig} from "../default";
+import {AdminConfig, TriageConfig} from "../default";
 import {getLabelsNames, matchAllOfAny} from "./common";
 import Github from '@octokit/rest';
 
@@ -120,7 +119,7 @@ export class TriagePRTask extends Task {
    * Gets the config for the merge plugin from Github or uses default if necessary
    */
   async getConfig(context: Context): Promise<TriageConfig> {
-    const repositoryConfig = await context.config<AppConfig>(CONFIG_FILE, appConfig);
+    const repositoryConfig = await this.getAppConfig(context);
     const config = repositoryConfig.triagePR;
     config.defaultMilestone = parseInt(<unknown>config.defaultMilestone as string, 10);
     config.needsTriageMilestone = parseInt(<unknown>config.needsTriageMilestone as string, 10);

--- a/functions/src/typings.ts
+++ b/functions/src/typings.ts
@@ -82,4 +82,26 @@ declare namespace GithubGQL {
   }
 }
 
+export interface Commit {
+  id: string;
+  tree_id: string;
+  distinct: boolean;
+  message: string;
+  timestamp: string;
+  url: string;
+  author: {
+    name: string;
+    email: string;
+    username: string;
+  };
+  committer: {
+    name: string;
+    email: string;
+    username: string;
+  };
+  added: string[];
+  removed: string[];
+  modified: string[];
+}
+
 export default GithubGQL;

--- a/functions/src/typings.ts
+++ b/functions/src/typings.ts
@@ -38,6 +38,10 @@ export const enum AUTHOR_ASSOCIATION {
   Owner = 'OWNER'
 }
 
+export interface CachedPullRequest extends Github.PullRequestsGetResponse {
+  pendingReviews?: number;
+}
+
 declare namespace GithubGQL {
   export interface PullRequest {
     labels: Labels;

--- a/functions/src/typings.ts
+++ b/functions/src/typings.ts
@@ -63,7 +63,7 @@ declare namespace GithubGQL {
   }
 
   export interface Commit {
-    status: Status;
+    status: Status|null;
   }
 
   export interface Status {


### PR DESCRIPTION
More improvementd to avoid the API rate limit errors:
- We only check the number of reviews on review events and then we cache this in Firebase so that we can update the Github status accordingly for the other type of events (avoid 0 to 2 unnecessary requests per event)
- We only get the repo config once per event. Instead of calling Github to get the config in each function that needs it, we pass it around (avoid 1 to 2 unnecessary requests per event)

Total = 1 to 4 requests avoided per event (most of the time 4), which is ~50 to 75% less requests per event for the PRs.