### PR TITLE
G3 check

### DIFF
--- a/functions/src/default.ts
+++ b/functions/src/default.ts
@@ -119,7 +119,7 @@ If you can't get the PR to a green state due to flakes or broken master, please 
     // set to true to disable
     disabled: true,
     // the label which when added triggers a rerun of the default CircleCI workflow.
-    triggerRerunLabel: 'Trigger CircleCI Rerun';
+    triggerRerunLabel: 'Trigger CircleCI Rerun'
   },
 };
 

--- a/functions/src/plugins/merge.ts
+++ b/functions/src/plugins/merge.ts
@@ -3,7 +3,7 @@ import {Application, Context} from "probot";
 import {MergeConfig} from "../default";
 import {addComment, addLabels, getGhPRLabels, getLabelsNames, matchAny, matchAnyFile, queryPR} from "./common";
 import {Task} from "./task";
-import {default as GithubGQL, AUTHOR_ASSOCIATION, REVIEW_STATE, STATUS_STATE, CachedPullRequest} from "../typings";
+import {default as GithubGQL, AUTHOR_ASSOCIATION, REVIEW_STATE, STATUS_STATE, CachedPullRequest, GQL_STATUS_STATE} from "../typings";
 
 // TODO(ocombe): create Typescript interfaces for each payload & DB data
 export class MergeTask extends Task {
@@ -221,9 +221,12 @@ export class MergeTask extends Task {
       switch(status.state) {
         case STATUS_STATE.Failure:
         case STATUS_STATE.Error:
+        case GQL_STATUS_STATE.Failure:
+        case GQL_STATUS_STATE.Error:
           checksStatus.failure.push(`status "${status.context}" is failing`);
           break;
         case STATUS_STATE.Pending:
+        case GQL_STATUS_STATE.Pending:
           checksStatus.pending.push(`status "${status.context}" is pending`);
           break;
       }

--- a/functions/src/plugins/rerun-circleci.ts
+++ b/functions/src/plugins/rerun-circleci.ts
@@ -1,11 +1,11 @@
-import {config} from 'firebase-functions';
+import {config as firebaseConfig} from 'firebase-functions';
 import {Application, Context} from "probot";
 import {Task} from "./task";
 import {RerunCircleCIConfig} from "../default";
 import Github from '@octokit/rest';
 import fetch from "node-fetch";
 
-let circleCIConfig = config().circleCI.token;
+let circleCIConfig = firebaseConfig().circleCI;
 
 // Check if we are in Firebase or in development
 if(!circleCIConfig) {
@@ -73,9 +73,10 @@ ${error.message}
         number: pullRequest.number,
         owner: owner,
         repo: repo,
-      }) 
-
-    } 
+      }).catch(err => {
+        throw err;
+      });
+    }
     await context.github.issues.removeLabel({
       name: config.triggerRerunLabel,
       number: pullRequest.number,
@@ -89,7 +90,6 @@ ${error.message}
    */
   async getConfig(context: Context): Promise<RerunCircleCIConfig> {
     const repositoryConfig = await this.getAppConfig(context);
-    const config = repositoryConfig.rerunCircleCI;
-    return config;
+    return repositoryConfig.rerunCircleCI;
   }
 }

--- a/functions/src/typings.ts
+++ b/functions/src/typings.ts
@@ -13,6 +13,13 @@ export const enum STATUS_STATE {
   Error = 'error'
 }
 
+export const enum GQL_STATUS_STATE {
+  Pending = 'PENDING',
+  Success = 'SUCCESS',
+  Failure = 'FAILURE',
+  Error = 'ERROR'
+}
+
 export const enum REVIEW_STATE {
   Pending = 'PENDING',
   Approved = 'APPROVED',
@@ -73,7 +80,7 @@ declare namespace GithubGQL {
   interface StatusContext {
     // node id
     id: string;
-    state: STATUS_STATE;
+    state: GQL_STATUS_STATE | STATUS_STATE;
     description: string;
     // name of the status, e.g. "ci/angular: merge status"
     context: string;


### PR DESCRIPTION
When the synchronize event is received after the PR created event, we are unable to update the PR with the g3 status because we don't know yet to which PR this commit belongs.
Now we will add the g3 status if it's missing (and g3 status is enabled for this repository) whenever a status update is requested.
This mitigates the Github events timing issues.