### PR TITLE
feat: support new draft status for PRs

### DIFF
--- a/functions/src/typings.ts
+++ b/functions/src/typings.ts
@@ -47,6 +47,8 @@ export const enum AUTHOR_ASSOCIATION {
 
 export interface CachedPullRequest extends Github.PullRequestsGetResponse {
   pendingReviews?: number;
+  mergeable_state?: string;
+  draft?: boolean;
 }
 
 declare namespace GithubGQL {


### PR DESCRIPTION
Github added a new "draft" mode for PRs, they also added new properties on events to be able to check if a PR is in draft mode or not.
This PR takes the draft mode into account in order to show the status as pending (because draft) instead of failing (because it was detected as not-mergeable, as if there was a conflict with master)