### PR TITLE
fix: g3Status check only checks against the branch being synced in g3

### DIFF
--- a/functions/src/default.ts
+++ b/functions/src/default.ts
@@ -46,7 +46,8 @@ export const appConfig: AppConfig = {
         "**/rollup.config.js",
         "**/BUILD.bazel",
         "packages/**/test/**",
-      ]
+      ],
+      syncedBranch: "master",
     },
 
     // comment that will be added to a PR when there is a conflict, leave empty or set to false to disable
@@ -146,6 +147,7 @@ export interface MergeConfig {
     url: string;
     include: string[];
     exclude: string[];
+    syncedBranch: string;
   };
   mergeConflictComment: string;
   mergeLabel: string;

--- a/functions/src/plugins/merge.ts
+++ b/functions/src/plugins/merge.ts
@@ -478,7 +478,9 @@ export class MergeTask extends Task {
     )) {
       // Checking if we need to add g3 status
       const files: Github.PullRequestsListFilesResponse = (await context.github.pullRequests.listFiles({owner, repo, number: pr.number})).data;
-      if(this.matchAnyFile(files.map(file => file.filename), config.g3Status.include, config.g3Status.exclude)) {
+      const pullRequest: Github.PullRequestsGetResponse = (await context.github.pullRequests.get({owner, repo, number: pr.number})).data;
+      if (pullRequest.base.ref == config.g3Status.syncedBranch &&
+        this.matchAnyFile(files.map(file => file.filename), config.g3Status.include, config.g3Status.exclude)) {
         // Only update g3 status if a commit was just pushed, or there was no g3 status
         if(context.payload.action === "synchronize" || !statuses.some(status => status.context === config.g3Status.context)) {
           const status = (await context.github.repos.createStatus({


### PR DESCRIPTION
Previously all changes where checked for if the file was synced to g3.
However only a single branches files are actually synced, typically
master. This change now confirms that changes are targetting a branch
we care about, if it does not the status is marked as passing.