### PR TITLE
refactor: allow use-case and confusing types to be marked as 'triaged'

### DIFF
--- a/functions/src/default.ts
+++ b/functions/src/default.ts
@@ -98,7 +98,14 @@ If you can't get the PR to a green state due to flakes or broken master, please 
     // arrays of labels that determine if an issue has been triaged by the caretaker
     l1TriageLabels: [["comp: *"]],
     // arrays of labels that determine if an issue has been fully triaged
-    l2TriageLabels: [["type: bug/fix", "severity*", "freq*", "comp: *"], ["type: feature", "comp: *"], ["type: refactor", "comp: *"], ["type: RFC / Discussion / question", "comp: *"]]
+    l2TriageLabels: [
+      ["type: bug/fix", "severity*", "freq*", "comp: *"],
+      ["type: use-case", "freq*", "comp: *"],
+      ["type: confusing", "freq*", "comp: *"],
+      ["type: feature", "comp: *"],
+      ["type: refactor", "comp: *"],
+      ["type: RFC / Discussion / question", "comp: *"]
+    ]
   },
 
   // triage for PRs

--- a/test/triage.spec.ts
+++ b/test/triage.spec.ts
@@ -59,6 +59,12 @@ describe('triage', () => {
 
       isTriaged = triageTask.isTriaged(config.l2TriageLabels, ['comp: common/http', 'type: bug/fix', 'freq1: low', 'severity3: broken']);
       expect(isTriaged).toBeTruthy();
+
+      isTriaged = triageTask.isTriaged(config.l2TriageLabels, ['comp: router', 'type: use-case', 'freq1: low'])
+      expect(isTriaged).toBeTruthy();
+
+      isTriaged = triageTask.isTriaged(config.l2TriageLabels, ['comp: router', 'type: confusing', 'freq1: low'])
+      expect(isTriaged).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Some issue reports don't really fall into any of the current buckets that count
towards triage level 2: bug/fix, feature, or refactor. Some reports are:
* working as intended but confusing - the labels might be 'type: confusing', 'comp: docs', 'comp: router'
* generally working as originally designed but a use-case could be argued for a different implementation.
 This type of report is a little hard to triage; it may be neither a bug, nor feature but more of a
 'type: use-case'. These may eventually turn into a bug/fix or feature, but can't necessarily be
 put in those buckets immediately.