### PR TITLE
docs: remove usages of whitelist and blacklist config comments

### DIFF
--- a/test/fixtures/angular-robot.yml
+++ b/test/fixtures/angular-robot.yml
@@ -11,13 +11,13 @@ size:
   # only comments if there is an actual change
   comment: false
   # set to control the set of artifacts
-  # `include` acts as a whitelist (only matching artifacts are analyzed)
+  # `include` filters to ensure only matching artifacts are analyzed
   # if `include` is not provided all artifacts are included
-  # `exclude` acts as a blacklist (matching artifacts will not be analyzed)
+  # `exclude` filters to ensure matching artifacts are not analyzed
   # `exclude` takes priority over `include`
   # Both options can be a partial path or a full path of an artifact
   # if a partial path, all artifacts within that path will be matched
-  # 
+  #
   # The below configuration will include `/path/to/one/artifact.js` and all artifacts
   # within `/path/to/two/` except `/path/to/two/artifact2.js`
   # include:


### PR DESCRIPTION
Removes usages of whitelits and blacklist in the test fixture config file
instead properly describing what the configuration is doing.