### PR TITLE
refactor: prepare for branch rename from `master` to `main`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "logs:functions": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "@firebase/app-types": "0.3.2",


### PR DESCRIPTION
Makes the logic for config detection a little more future-proof
and less hard-coded.