### PR TITLE
fix(size): set the follow value for node-fetch to 100

### DIFF
--- a/functions/src/plugins/size.ts
+++ b/functions/src/plugins/size.ts
@@ -368,7 +368,7 @@ export class SizeTask extends Task {
       headers['Circle-Token'] = token;
     }
 
-    const artifactsResponse = await fetch(artifactUrl, {headers});
+    const artifactsResponse = await fetch(artifactUrl, {headers, follow: 100});
 
     let {items: artifacts} = (await artifactsResponse.json() as {items: CircleCiArtifact[]});
     if (include) {


### PR DESCRIPTION
By setting the follow value for our fetch request via node-fetch, we will follow through more
recieved redirects.  This is in response to an issue in which CircleCI sent us through more
redirects than we expected and caused our CI to fail.