### PR TITLE
Avoid message for failing checks when merge label is applied with caretaker note

### DIFF
--- a/functions/src/plugins/merge.ts
+++ b/functions/src/plugins/merge.ts
@@ -60,7 +60,10 @@ export class MergeTask extends Task {
     let updateStatus = false;
     let statuses: GithubGQL.StatusContext[];
 
-    if(newLabel === config.mergeLabel) {
+    const labels = getLabelsNames(pr.labels)
+    const hasCaretakerNote = labels.includes('action: caretaker note')
+
+     if(newLabel === config.mergeLabel && !hasCaretakerNote) {
       this.logDebug({context}, `Checking merge label`);
 
       statuses = await this.getStatuses(context, pr.number, config);
@@ -79,7 +82,7 @@ export class MergeTask extends Task {
           });
         }
       }
-    } else if(config.mergeLinkedLabels && config.mergeLinkedLabels.includes(newLabel) && !getLabelsNames(pr.labels).includes(config.mergeLabel)) {
+    } else if(config.mergeLinkedLabels && config.mergeLinkedLabels.includes(newLabel) && !labels.includes(config.mergeLabel)) {
       // Add the merge label when we add a linked label
       addLabels(context.github, owner, repo, pr.number, [config.mergeLabel])
         .catch(); // If it fails it's because we're trying to add a label that already exists

--- a/functions/src/plugins/merge.ts
+++ b/functions/src/plugins/merge.ts
@@ -1,10 +1,17 @@
 import Github from '@octokit/rest';
-import minimatch from "minimatch";
-import {Application, Context} from "probot";
-import {MergeConfig} from "../default";
-import {addComment, addLabels, getGhPRLabels, getLabelsNames, matchAny, queryPR} from "./common";
-import {Task} from "./task";
-import {default as GithubGQL, AUTHOR_ASSOCIATION, REVIEW_STATE, STATUS_STATE, CachedPullRequest, GQL_STATUS_STATE} from "../typings";
+import minimatch from 'minimatch';
+import {Application, Context} from 'probot';
+import {MergeConfig} from '../default';
+import {addComment, addLabels, getGhPRLabels, getLabelsNames, matchAny, queryPR} from './common';
+import {Task} from './task';
+import {
+  default as GithubGQL,
+  AUTHOR_ASSOCIATION,
+  REVIEW_STATE,
+  STATUS_STATE,
+  CachedPullRequest,
+  GQL_STATUS_STATE,
+} from '../typings';
 
 // TODO(ocombe): create Typescript interfaces for each payload & DB data
 export class MergeTask extends Task {
@@ -19,29 +26,32 @@ export class MergeTask extends Task {
     // PR looses a label
     this.dispatch('pull_request.unlabeled', this.onPRUnlabeled.bind(this));
     // PR updated or received a new status update from another app
-    this.dispatch([
-      'status',
-      'pull_request.synchronize',
-      'pull_request.edited' // Editing a PR can change the base branch (not just text content)
-    ], this.updateStatus.bind(this));
+    this.dispatch(
+      [
+        'status',
+        'pull_request.synchronize',
+        'pull_request.edited', // Editing a PR can change the base branch (not just text content)
+      ],
+      this.updateStatus.bind(this)
+    );
 
     // PR review updated or received
-    this.dispatch([
-      'pull_request.review_requested',
-      'pull_request.review_request_removed',
-      'pull_request_review.submitted',
-      'pull_request_review.dismissed',
-    ], this.updateReview.bind(this));
+    this.dispatch(
+      [
+        'pull_request.review_requested',
+        'pull_request.review_request_removed',
+        'pull_request_review.submitted',
+        'pull_request_review.dismissed',
+      ],
+      this.updateReview.bind(this)
+    );
     // PR created or updated
-    this.dispatch([
-      'pull_request.synchronize',
-      'pull_request.opened'
-    ], this.onSynchronize.bind(this));
+    this.dispatch(
+      ['pull_request.synchronize', 'pull_request.opened'],
+      this.onSynchronize.bind(this)
+    );
     // PR closed or reopened (but content not changed)
-    this.dispatch([
-      'pull_request.closed',
-      'pull_request.reopened'
-    ], this.onUpdate.bind(this));
+    this.dispatch(['pull_request.closed', 'pull_request.reopened'], this.onUpdate.bind(this));
   }
 
   /**
@@ -53,42 +63,60 @@ export class MergeTask extends Task {
     let pr: Github.PullRequestsGetResponse = context.payload.pull_request;
     const config = await this.getConfig(context);
     const {owner, repo} = context.repo();
-    pr = await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, pr).catch(err => {
+    pr = await this.updateDbPR(
+      context.github,
+      owner,
+      repo,
+      pr.number,
+      context.payload.repository.id,
+      pr
+    ).catch(err => {
       throw err;
     });
 
     let updateStatus = false;
     let statuses: GithubGQL.StatusContext[];
 
-    const labels = getLabelsNames(pr.labels)
-    const hasCaretakerNote = labels.includes('action: caretaker note')
+    const labels = getLabelsNames(pr.labels);
+    const hasCaretakerNote = labels.includes('merge: caretaker note');
 
-     if(newLabel === config.mergeLabel && !hasCaretakerNote) {
+    if (newLabel === config.mergeLabel && !hasCaretakerNote) {
       this.logDebug({context}, `Checking merge label`);
 
       statuses = await this.getStatuses(context, pr.number, config);
       const checks = await this.getChecksStatus(context, pr, config, pr.labels, statuses);
 
-      if(checks.failure.length > 0) {
-        const failures = checks.failure.map(check => `&nbsp;&nbsp;&nbsp;&nbsp;![failure](https://raw.githubusercontent.com/angular/github-robot/master/assets/failing.png) ${check}`);
-        const pendings = checks.pending.map(check => `&nbsp;&nbsp;&nbsp;&nbsp;![pending](https://raw.githubusercontent.com/angular/github-robot/master/assets/pending.png) ${check}`);
+      if (checks.failure.length > 0) {
+        const failures = checks.failure.map(
+          check =>
+            `&nbsp;&nbsp;&nbsp;&nbsp;![failure](https://raw.githubusercontent.com/angular/github-robot/master/assets/failing.png) ${check}`
+        );
+        const pendings = checks.pending.map(
+          check =>
+            `&nbsp;&nbsp;&nbsp;&nbsp;![pending](https://raw.githubusercontent.com/angular/github-robot/master/assets/pending.png) ${check}`
+        );
         const reasons = `${failures.concat(pendings).join('\n')}`;
 
         let body = config.mergeRemovedComment;
-        if(body) {
-          body = body.replace("{{MERGE_LABEL}}", config.mergeLabel).replace("{{PLACEHOLDER}}", reasons);
+        if (body) {
+          body = body
+            .replace('{{MERGE_LABEL}}', config.mergeLabel)
+            .replace('{{PLACEHOLDER}}', reasons);
           addComment(context.github, owner, repo, pr.number, body).catch(err => {
             throw err;
           });
         }
       }
-    } else if(config.mergeLinkedLabels && config.mergeLinkedLabels.includes(newLabel) && !labels.includes(config.mergeLabel)) {
+    } else if (
+      config.mergeLinkedLabels &&
+      config.mergeLinkedLabels.includes(newLabel) &&
+      !labels.includes(config.mergeLabel)
+    ) {
       // Add the merge label when we add a linked label
-      addLabels(context.github, owner, repo, pr.number, [config.mergeLabel])
-        .catch(); // If it fails it's because we're trying to add a label that already exists
+      addLabels(context.github, owner, repo, pr.number, [config.mergeLabel]).catch(); // If it fails it's because we're trying to add a label that already exists
     }
 
-    if(this.matchLabel(newLabel, pr.labels, config)) {
+    if (this.matchLabel(newLabel, pr.labels, config)) {
       updateStatus = true;
     }
 
@@ -108,27 +136,44 @@ export class MergeTask extends Task {
     let pr = context.payload.pull_request;
     // we need the list of labels from Github because we might be adding multiple labels at once
     // and we could overwrite some labels because of a race condition
-    pr = await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, pr).catch(err => {
+    pr = await this.updateDbPR(
+      context.github,
+      owner,
+      repo,
+      pr.number,
+      context.payload.repository.id,
+      pr
+    ).catch(err => {
       throw err;
     });
 
-    if(this.matchLabel(removedLabel, pr.labels, config)) {
+    if (this.matchLabel(removedLabel, pr.labels, config)) {
       this.updateStatus(context, config, true, pr.labels).catch(err => {
         throw err;
       });
     }
   }
 
-  private matchLabel(label: string, labels: GithubGQL.Labels['nodes'], config: MergeConfig): boolean {
-    return matchAny([label], config.checks.requiredLabels)
-      || matchAny([label], config.checks.forbiddenLabels)
-      || (getLabelsNames(labels).includes(config.mergeLabel) && matchAny([label], config.checks.requiredLabelsWhenMergeReady || []));
+  private matchLabel(
+    label: string,
+    labels: GithubGQL.Labels['nodes'],
+    config: MergeConfig
+  ): boolean {
+    return (
+      matchAny([label], config.checks.requiredLabels) ||
+      matchAny([label], config.checks.forbiddenLabels) ||
+      (getLabelsNames(labels).includes(config.mergeLabel) &&
+        matchAny([label], config.checks.requiredLabelsWhenMergeReady || []))
+    );
   }
 
   /**
    * Gets the list of labels from a PR.
    */
-  private async getPRLabels(context: Context, pr?: Github.PullRequestsGetResponse): Promise<GithubGQL.Labels['nodes']> {
+  private async getPRLabels(
+    context: Context,
+    pr?: Github.PullRequestsGetResponse
+  ): Promise<GithubGQL.Labels['nodes']> {
     const {owner, repo} = context.repo();
     pr = pr || context.payload.pull_request;
     const doc = this.pullRequests.doc(pr.id.toString());
@@ -136,90 +181,105 @@ export class MergeTask extends Task {
     let labels: GithubGQL.Labels['nodes'];
 
     // if the PR is already in Firebase
-    if(dbPR.exists) {
+    if (dbPR.exists) {
       labels = dbPR.data().labels;
 
       // if we have the labels listed in the PR
-      if(labels) {
+      if (labels) {
         return labels;
       }
     }
 
     // otherwise get the labels from Github and update Firebase
     labels = await getGhPRLabels(context.github, owner, repo, pr.number);
-    await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, {...pr, labels});
+    await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, {
+      ...pr,
+      labels,
+    });
     return labels;
   }
 
   /**
    * Based on the repository config, returns the list of checks that failed for this PR.
    */
-  private async getChecksStatus(context: Context, pr: CachedPullRequest, config: MergeConfig, labels: Github.PullRequestsGetResponseLabelsItem[] = [], statuses?: GithubGQL.StatusContext[]): Promise<ChecksStatus> {
+  private async getChecksStatus(
+    context: Context,
+    pr: CachedPullRequest,
+    config: MergeConfig,
+    labels: Github.PullRequestsGetResponseLabelsItem[] = [],
+    statuses?: GithubGQL.StatusContext[]
+  ): Promise<ChecksStatus> {
     const checksStatus: ChecksStatus = {
       pending: [],
-      failure: []
+      failure: [],
     };
     const labelsNames = getLabelsNames(labels);
 
     // Check if there is any merge conflict
-    if(config.checks.noConflict) {
+    if (config.checks.noConflict) {
       // If mergeable is null, we need to get the updated status
-      if(pr.mergeable === null) {
+      if (pr.mergeable === null) {
         const {owner, repo} = context.repo();
-        pr = await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id);
+        pr = await this.updateDbPR(
+          context.github,
+          owner,
+          repo,
+          pr.number,
+          context.payload.repository.id
+        );
       }
       // Check if there is a conflict with the base branch
-      if(pr.mergeable === false) {
+      if (pr.mergeable === false) {
         checksStatus.failure.push(`conflicts with base branch "${pr.base.ref}"`);
       }
     }
 
     // Check if all required labels are present
-    if(config.checks.requiredLabels) {
+    if (config.checks.requiredLabels) {
       const missingLabels: string[] = [];
       config.checks.requiredLabels.forEach(reqLabel => {
-        if(!labelsNames.some(label => !!label.match(new RegExp(reqLabel)))) {
+        if (!labelsNames.some(label => !!label.match(new RegExp(reqLabel)))) {
           missingLabels.push(reqLabel);
         }
       });
 
-      if(missingLabels.length > 0) {
+      if (missingLabels.length > 0) {
         checksStatus.pending.push(`missing required labels: ${missingLabels.join(', ')}`);
       }
     }
 
     // Check if all required labels when merge ready are present
-    if(labelsNames.includes(config.mergeLabel) && config.checks.requiredLabelsWhenMergeReady) {
+    if (labelsNames.includes(config.mergeLabel) && config.checks.requiredLabelsWhenMergeReady) {
       const missingLabels: string[] = [];
       config.checks.requiredLabelsWhenMergeReady.forEach(reqLabel => {
-        if(!labelsNames.some(label => !!label.match(new RegExp(reqLabel)))) {
+        if (!labelsNames.some(label => !!label.match(new RegExp(reqLabel)))) {
           missingLabels.push(reqLabel);
         }
       });
 
-      if(missingLabels.length > 0) {
+      if (missingLabels.length > 0) {
         checksStatus.pending.push(`missing required labels: ${missingLabels.join(', ')}`);
       }
     }
 
     // Check if any forbidden label is present
-    if(config.checks.forbiddenLabels) {
+    if (config.checks.forbiddenLabels) {
       const fbdLabels: string[] = [];
       config.checks.forbiddenLabels.forEach(fbdLabel => {
-        if(labelsNames.some(label => !!label.match(new RegExp(fbdLabel)))) {
+        if (labelsNames.some(label => !!label.match(new RegExp(fbdLabel)))) {
           fbdLabels.push(fbdLabel);
         }
       });
 
-      if(fbdLabels.length > 0) {
+      if (fbdLabels.length > 0) {
         checksStatus.pending.push(`forbidden labels detected: ${fbdLabels.join(', ')}`);
       }
     }
 
     // Check if we have any failed/pending external status
-    statuses = statuses || await this.getStatuses(context, pr.number, config);
+    statuses = statuses || (await this.getStatuses(context, pr.number, config));
     statuses.forEach(status => {
-      switch(status.state) {
+      switch (status.state) {
         case STATUS_STATE.Failure:
         case STATUS_STATE.Error:
         case GQL_STATUS_STATE.Failure:
@@ -234,30 +294,39 @@ export class MergeTask extends Task {
     });
 
     // Check if all required statuses are present
-    if(config.checks.requiredStatuses) {
+    if (config.checks.requiredStatuses) {
       config.checks.requiredStatuses.forEach(reqCheck => {
-        if(!statuses.some(status => !!status.context.match(new RegExp(reqCheck)))) {
+        if (!statuses.some(status => !!status.context.match(new RegExp(reqCheck)))) {
           checksStatus.pending.push(`missing required status "${reqCheck}"`);
         }
       });
     }
 
     // Check if there is any review pending or that requested changes
-    if(config.checks.requireReviews) {
+    if (config.checks.requireReviews) {
       let nbPendingReviews = pr.pendingReviews;
       // Because we're adding cache for this value progressively, ensure that we have the data available
       // TODO(ocombe): remove this when all DB PRs have been updated
-      if(typeof nbPendingReviews !== 'number') {
+      if (typeof nbPendingReviews !== 'number') {
         nbPendingReviews = await this.getPendingReviews(context, pr);
         pr.pendingReviews = nbPendingReviews;
         const {owner, repo} = context.repo();
-        await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, pr).catch(err => {
+        await this.updateDbPR(
+          context.github,
+          owner,
+          repo,
+          pr.number,
+          context.payload.repository.id,
+          pr
+        ).catch(err => {
           throw err;
         });
       }
 
-      if(nbPendingReviews > 0) {
-        checksStatus.pending.push(`${nbPendingReviews} pending code review${nbPendingReviews > 1 ? 's' : ''}`);
+      if (nbPendingReviews > 0) {
+        checksStatus.pending.push(
+          `${nbPendingReviews} pending code review${nbPendingReviews > 1 ? 's' : ''}`
+        );
       }
     }
 
@@ -272,12 +341,17 @@ export class MergeTask extends Task {
   async getPendingReviews(context: Context, pr: CachedPullRequest): Promise<number> {
     const {owner, repo} = context.repo();
     // We can have a lot of reviews on a PR, we need to paginate to get all of them
-    const reviews = (await context.github.paginate(context.github.pullRequests.listReviews({
-      owner,
-      repo,
-      number: pr.number,
-      per_page: 100
-    }), pages => (pages as any).data) as Review[])
+    const reviews = (
+      (await context.github.paginate(
+        context.github.pullRequests.listReviews({
+          owner,
+          repo,
+          number: pr.number,
+          per_page: 100,
+        }),
+        pages => (pages as any).data
+      )) as Review[]
+    )
       // We only want reviews with state: PENDING, APPROVED, CHANGES_REQUESTED, DISMISSED.
       // We ignore comments because they can be done after a review was approved / refused, and also because
       // anyone can add comments, it doesn't mean that it's someone who is actually reviewing the PR
@@ -285,13 +359,18 @@ export class MergeTask extends Task {
       // We ignore reviews from individuals who aren't members of the repository
       .filter(review => review.author_association !== AUTHOR_ASSOCIATION.None)
       // Order by latest review first
-      .sort((review1, review2) => new Date(review2.submitted_at).getTime() - new Date(review1.submitted_at).getTime());
+      .sort(
+        (review1, review2) =>
+          new Date(review2.submitted_at).getTime() - new Date(review1.submitted_at).getTime()
+      );
 
     // The list of requested reviewers only contains people that have been requested for review but have not
     // given the review yet. Once they do, they disappear from this list, and we need to check the reviews.
     // We only take the reviews from users and ignore team reviews so that we don't conflict with Github code owners
     // that automatically add team to the reviewers list
-    const reviewRequests =(await context.github.pullRequests.listReviewRequests({owner, repo, number: pr.number})).data.users || [];
+    const reviewRequests =
+      (await context.github.pullRequests.listReviewRequests({owner, repo, number: pr.number})).data
+        .users || [];
 
     const usersReviews: number[] = [];
     const finalReviews: any[] = [];
@@ -300,14 +379,17 @@ export class MergeTask extends Task {
     // changes_requested or dismissed)
     reviews.forEach(review => {
       const reviewUser = review.user.id;
-      if(!usersReviews.includes(reviewUser)) {
+      if (!usersReviews.includes(reviewUser)) {
         usersReviews.push(reviewUser);
         finalReviews.push(review);
       }
     });
 
     // We want the list of "non-approved" reviews, so we only keep the reviews that are pending / requested changes
-    const nonApprovedReviews = finalReviews.filter(review => review.state === REVIEW_STATE.Pending || review.state === REVIEW_STATE.ChangesRequest);
+    const nonApprovedReviews = finalReviews.filter(
+      review =>
+        review.state === REVIEW_STATE.Pending || review.state === REVIEW_STATE.ChangesRequest
+    );
 
     return reviewRequests.length + nonApprovedReviews.length;
   }
@@ -322,7 +404,7 @@ export class MergeTask extends Task {
 
     await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, {
       ...pr,
-      synchronized_at: new Date()
+      synchronized_at: new Date(),
     });
     this.logDebug({context}, `Updated synchronized date`);
   }
@@ -335,7 +417,14 @@ export class MergeTask extends Task {
     const pr = context.payload.pull_request;
     const {owner, repo} = context.repo();
 
-    await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, pr);
+    await this.updateDbPR(
+      context.github,
+      owner,
+      repo,
+      pr.number,
+      context.payload.repository.id,
+      pr
+    );
     this.logDebug({context}, `Updated PR data`);
   }
 
@@ -346,7 +435,7 @@ export class MergeTask extends Task {
   // todo(OCOMBE): change it to use database trigger
   async onPush(context: Context): Promise<void> {
     const config = await this.getConfig(context);
-    if(!config.checks.noConflict) {
+    if (!config.checks.noConflict) {
       return;
     }
     const {owner, repo} = context.repo();
@@ -354,7 +443,8 @@ export class MergeTask extends Task {
     let ref = context.payload.ref.split('/');
     ref = ref[ref.length - 1];
 
-    const pullRequests = await this.pullRequests.where('state', '==', 'open')
+    const pullRequests = await this.pullRequests
+      .where('state', '==', 'open')
       .where('base.ref', '==', ref)
       .where('repository.id', '==', repoId)
       .get();
@@ -365,23 +455,34 @@ export class MergeTask extends Task {
       // TODO(ocombe): we might need to setTimeout this until we get a mergeable value !== null (or use probot scheduler)
       pr = await this.updateDbPR(context.github, owner, repo, pr.number, repoId);
 
-      if(pr.mergeable === false) {
+      if (pr.mergeable === false) {
         // Get the comments since the last time the PR was synchronized
-        if((pr.conflict_comment_at && pr.synchronized_at && pr.conflict_comment_at >= pr.synchronized_at) || (!pr.synchronized_at && pr.conflict_comment_at)) {
-          this.logDebug({context}, `This PR already contains a merge conflict comment since the last synchronized date, skipping it`);
+        if (
+          (pr.conflict_comment_at &&
+            pr.synchronized_at &&
+            pr.conflict_comment_at >= pr.synchronized_at) ||
+          (!pr.synchronized_at && pr.conflict_comment_at)
+        ) {
+          this.logDebug(
+            {context},
+            `This PR already contains a merge conflict comment since the last synchronized date, skipping it`
+          );
           return;
         }
 
-        if(config.mergeConflictComment) {
+        if (config.mergeConflictComment) {
           await context.github.issues.createComment({
             owner,
             repo,
             number: pr.number,
-            body: config.mergeConflictComment.replace("{{PRAuthor}}", pr.user.login)
+            body: config.mergeConflictComment.replace('{{PRAuthor}}', pr.user.login),
           });
-          this.pullRequests.doc(pr.id.toString()).set({conflict_comment_at: new Date()}, {merge: true}).catch(err => {
-            throw err;
-          });
+          this.pullRequests
+            .doc(pr.id.toString())
+            .set({conflict_comment_at: new Date()}, {merge: true})
+            .catch(err => {
+              throw err;
+            });
           this.log({context}, `Added comment: conflict with the base branch "${pr.base.ref}"`);
         }
       }
@@ -390,7 +491,7 @@ export class MergeTask extends Task {
 
   private async updateReview(context: Context): Promise<void> {
     const config = await this.getConfig(context);
-    if(config.status.disabled || !config.checks.requireReviews) {
+    if (config.status.disabled || !config.checks.requireReviews) {
       return;
     }
     const pr: Github.PullRequestsGetResponse = context.payload.pull_request;
@@ -405,129 +506,172 @@ export class MergeTask extends Task {
   /**
    * Updates the status of a PR.
    */
-  private async updateStatus(context: Context, config?: MergeConfig, updateStatus = true, labels?: Github.PullRequestsGetResponseLabelsItem[], statuses?: GithubGQL.StatusContext[]): Promise<void> {
+  private async updateStatus(
+    context: Context,
+    config?: MergeConfig,
+    updateStatus = true,
+    labels?: Github.PullRequestsGetResponseLabelsItem[],
+    statuses?: GithubGQL.StatusContext[]
+  ): Promise<void> {
     let updateG3Status = false;
-    if(context.payload.action === "synchronize") {
+    if (context.payload.action === 'synchronize') {
       updateG3Status = true;
     }
-    if(!updateStatus && !updateG3Status) {
+    if (!updateStatus && !updateG3Status) {
       return;
     }
-    config = config || await this.getConfig(context);
-    if(config.status.disabled) {
+    config = config || (await this.getConfig(context));
+    if (config.status.disabled) {
       return;
     }
     let sha, pr;
     const {owner, repo} = context.repo();
 
-    switch(context.name) {
+    switch (context.name) {
       case 'pull_request':
       case 'pull_request_review':
         sha = context.payload.pull_request.head.sha;
         pr = context.payload.pull_request;
-        pr = await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id, pr).catch(err => {
+        pr = await this.updateDbPR(
+          context.github,
+          owner,
+          repo,
+          pr.number,
+          context.payload.repository.id,
+          pr
+        ).catch(err => {
           throw err;
         });
-        if(!labels) {
-          labels = pr.labels || await this.getPRLabels(context);
+        if (!labels) {
+          labels = pr.labels || (await this.getPRLabels(context));
         }
         break;
       case 'status':
         // Ignore status update events that are coming from this bot
-        if(context.payload.context === config.status.context) {
+        if (context.payload.context === config.status.context) {
           this.logDebug({context}, `Update status coming from this bot, ignored`);
           return;
         }
         // Ignore status events for commits coming directly from the default branch (most likely using github edit)
         // because they are not coming from a PR (e.g. travis runs for all commits and triggers a status update)
-        if(context.payload.branches.name === context.payload.repository.default_branch) {
-          this.logDebug({context}, `Update status coming directly from the default branch (${context.payload.branches.name}), ignored`);
+        if (context.payload.branches.name === context.payload.repository.default_branch) {
+          this.logDebug(
+            {context},
+            `Update status coming directly from the default branch (${context.payload.branches.name}), ignored`
+          );
           return;
         }
         sha = context.payload.sha;
         pr = await this.findPrBySha(sha, context.payload.repository.id);
 
-        if(!pr) {
+        if (!pr) {
           // The repository data was previously stored as a simple id, checking if this PR still has old data
-          const matches = (await this.pullRequests.where('head.sha', '==', sha)
+          const matches = await this.pullRequests
+            .where('head.sha', '==', sha)
             .where('repository', '==', context.payload.repository.id)
-            .get());
+            .get();
           matches.forEach(async doc => {
             pr = doc.data();
           });
         }
         // Either init has not finished yet and we don't have this PR in the DB, or it's a status update for a commit
         // made directly on a branch without a PR (e.g. travis runs for all commits and triggers a status update)
-        if(!pr) {
-          this.logWarn({context}, `Update status for unknown PR, ignored. Head sha == ${sha}, repository == ${context.payload.repository.id}`);
+        if (!pr) {
+          this.logWarn(
+            {context},
+            `Update status for unknown PR, ignored. Head sha == ${sha}, repository == ${context.payload.repository.id}`
+          );
           return;
         } else {
           // make sure that we have updated data
-          pr = await this.updateDbPR(context.github, owner, repo, pr.number, context.payload.repository.id);
+          pr = await this.updateDbPR(
+            context.github,
+            owner,
+            repo,
+            pr.number,
+            context.payload.repository.id
+          );
         }
-        if(!labels) {
-          labels = pr.labels || await getGhPRLabels(context.github, owner, repo, pr.number);
+        if (!labels) {
+          labels = pr.labels || (await getGhPRLabels(context.github, owner, repo, pr.number));
         }
         break;
       default:
         throw new Error(`Unhandled event ${context.name} in updateStatus`);
     }
 
-    statuses = statuses || await this.getStatuses(context, pr.number, config);
+    statuses = statuses || (await this.getStatuses(context, pr.number, config));
 
-    if(config.g3Status && !config.g3Status.disabled && (updateG3Status ||
-      // Check if the g3status is missing
-      !statuses.some(status => status.context === config.g3Status.context)
-    )) {
+    if (
+      config.g3Status &&
+      !config.g3Status.disabled &&
+      (updateG3Status ||
+        // Check if the g3status is missing
+        !statuses.some(status => status.context === config.g3Status.context))
+    ) {
       // Checking if we need to add g3 status
-      const files: Github.PullRequestsListFilesResponse = await context.github.paginate(
+      const files: Github.PullRequestsListFilesResponse = (await context.github.paginate(
         context.github.pullRequests.listFiles({owner, repo, number: pr.number}),
-        pages => (pages as any).data) as Github.PullRequestsListFilesResponse;
+        pages => (pages as any).data
+      )) as Github.PullRequestsListFilesResponse;
       (await context.github.pullRequests.listFiles({owner, repo, number: pr.number})).data;
-      if(this.matchAnyFile(files.map(file => file.filename), config.g3Status.include, config.g3Status.exclude)) {
+      if (
+        this.matchAnyFile(
+          files.map(file => file.filename),
+          config.g3Status.include,
+          config.g3Status.exclude
+        )
+      ) {
         // Only update g3 status if a commit was just pushed, or there was no g3 status
-        if(context.payload.action === "synchronize" || !statuses.some(status => status.context === config.g3Status.context)) {
-          const status = (await context.github.repos.createStatus({
-            owner,
-            repo,
-            sha: sha,
-            context: config.g3Status.context,
-            state: STATUS_STATE.Pending,
-            description: config.g3Status.pendingDesc.replace("{{PRNumber}}", pr.number),
-            target_url: config.g3Status.url
-          })).data as any as GithubGQL.StatusContext;
+        if (
+          context.payload.action === 'synchronize' ||
+          !statuses.some(status => status.context === config.g3Status.context)
+        ) {
+          const status = (
+            await context.github.repos.createStatus({
+              owner,
+              repo,
+              sha: sha,
+              context: config.g3Status.context,
+              state: STATUS_STATE.Pending,
+              description: config.g3Status.pendingDesc.replace('{{PRNumber}}', pr.number),
+              target_url: config.g3Status.url,
+            })
+          ).data as any as GithubGQL.StatusContext;
           statuses.push(status);
           this.log({context}, `Updated g3 status to pending`);
         }
       } else {
-        const status = (await context.github.repos.createStatus({
-          owner,
-          repo,
-          sha: pr.head.sha,
-          context: config.g3Status.context,
-          state: STATUS_STATE.Success,
-          description: config.g3Status.successDesc
-        })).data as any as GithubGQL.StatusContext;
+        const status = (
+          await context.github.repos.createStatus({
+            owner,
+            repo,
+            sha: pr.head.sha,
+            context: config.g3Status.context,
+            state: STATUS_STATE.Success,
+            description: config.g3Status.successDesc,
+          })
+        ).data as any as GithubGQL.StatusContext;
         statuses.push(status);
         this.log({context}, `Updated g3 status to success`);
       }
     }
 
-    if(updateStatus) {
+    if (updateStatus) {
       const statusParams: Github.ReposCreateStatusParams = {
         owner,
         repo,
         sha: sha,
         context: config.status.context,
-        state: STATUS_STATE.Success
+        state: STATUS_STATE.Success,
       };
 
       const failedChecks = await this.getChecksStatus(context, pr, config, labels, statuses);
 
-      if(failedChecks.failure.length > 0) {
+      if (failedChecks.failure.length > 0) {
         statusParams.state = STATUS_STATE.Failure;
         statusParams.description = failedChecks.failure.concat(failedChecks.pending).join(', ');
-      } else if(failedChecks.pending.length > 0) {
+      } else if (failedChecks.pending.length > 0) {
         statusParams.state = STATUS_STATE.Pending;
         statusParams.description = failedChecks.pending.join(', ');
       } else {
@@ -536,11 +680,14 @@ export class MergeTask extends Task {
       }
 
       // Capitalize first letter
-      statusParams.description = statusParams.description.replace(statusParams.description[0], statusParams.description[0].toUpperCase());
+      statusParams.description = statusParams.description.replace(
+        statusParams.description[0],
+        statusParams.description[0].toUpperCase()
+      );
       const desc = statusParams.description;
 
       // TODO(ocombe): add a link to a dynamic page with the complete status & some description of what's required
-      if(statusParams.description.length > 140) {
+      if (statusParams.description.length > 140) {
         statusParams.description = statusParams.description.substring(0, 137) + '...';
       }
 
@@ -552,11 +699,18 @@ export class MergeTask extends Task {
   /**
    * Get all external statuses except for the one added by this bot
    */
-  private async getStatuses(context: Context, number: number, config?: MergeConfig): Promise<GithubGQL.StatusContext[]> {
+  private async getStatuses(
+    context: Context,
+    number: number,
+    config?: MergeConfig
+  ): Promise<GithubGQL.StatusContext[]> {
     const {owner, repo} = context.repo();
-    config = config || await this.getConfig(context);
+    config = config || (await this.getConfig(context));
 
-    const status = (await queryPR<GithubGQL.PullRequest>(context.github, `
+    const status = (
+      await queryPR<GithubGQL.PullRequest>(
+        context.github,
+        `
       commits(last: 1) {
         nodes {
           commit {
@@ -573,10 +727,15 @@ export class MergeTask extends Task {
           }
         }
       }
-    `, {owner, repo, number})).commits.nodes[0].commit.status;
+    `,
+        {owner, repo, number}
+      )
+    ).commits.nodes[0].commit.status;
 
-    if(status) {
-      return status.contexts.filter((statusContext: GithubGQL.StatusContext) => statusContext.context !== config.status.context);
+    if (status) {
+      return status.contexts.filter(
+        (statusContext: GithubGQL.StatusContext) => statusContext.context !== config.status.context
+      );
     }
     return [];
   }
@@ -594,7 +753,9 @@ export class MergeTask extends Task {
    * logging of match checking.
    */
   private matchAnyFile(names: string[], patterns: string[], negPatterns: string[] = []): boolean {
-    this.logDebug('Checking for any file that matches a pattern and does not match any negPatterns');
+    this.logDebug(
+      'Checking for any file that matches a pattern and does not match any negPatterns'
+    );
     let matches = false;
     names.forEach(name => {
       const matchesPattern = patterns.find((pattern: string) => minimatch(name, pattern));
@@ -603,7 +764,11 @@ export class MergeTask extends Task {
         matchesNegPattern = negPatterns.find((negPattern: string) => minimatch(name, negPattern));
       }
       const currentFileMatched = !!(matchesPattern && !matchesNegPattern);
-      this.logDebug(`Matched: ${currentFileMatched} | File: ${name} | Pattern Matched: ${matchesPattern || 'No Match'} | NegPattern Matched: ${matchesNegPattern || 'No Match'}`);
+      this.logDebug(
+        `Matched: ${currentFileMatched} | File: ${name} | Pattern Matched: ${
+          matchesPattern || 'No Match'
+        } | NegPattern Matched: ${matchesNegPattern || 'No Match'}`
+      );
       matches = matches || currentFileMatched;
     });
     this.logDebug(`Overall Result of matchAnyFile: ${matches}`);


### PR DESCRIPTION
Currently when someone has a red PR and applies a caretaker note together with the action: merge label- a huge comment will be posted by the robot listing all the failed checks. This is generally a good thing but when the PR author already acknowledges these e.g. failures and added an explicit note (like merge assistance)- the message from the robot is spam and pollutes the PR comment history, potentially making the caretaker note difficult to find.

This commit never adds such a message when a caretaker note is applied. The label is non-configurable since Angular uses consistent labeling at this point (and the robot is mostly a legacy artifact currently)